### PR TITLE
Send options with renderers

### DIFF
--- a/lib/media_embed/handler.rb
+++ b/lib/media_embed/handler.rb
@@ -8,11 +8,11 @@ module MediaEmbed
 
     def template_for(url, options = {})
       template = if match = youtube?(url)
-                   Video.youtube_template(match[CODE])
+                   Video.youtube_template(match[CODE], options)
                  elsif match = vimeo?(url)
-                   Video.vimeo_template(match[CODE])
+                   Video.vimeo_template(match[CODE], options)
                  elsif match = soundcloud?(url)
-                   Podcast.soundcloud_template(match[CODE])
+                   Podcast.soundcloud_template(match[CODE], options)
                  else
                    ''
                  end


### PR DESCRIPTION
Options were falling useless in `template_for`. This commit sends them to the template renderers so they can be used. The latter were expecting these too.
